### PR TITLE
[BUGFIX] Avoid serialization of TestSystem

### DIFF
--- a/src/TestingFramework/TestCase/FunctionalTestCase.php
+++ b/src/TestingFramework/TestCase/FunctionalTestCase.php
@@ -149,6 +149,19 @@ abstract class FunctionalTestCase extends AbstractTestCase
     private $testSystem = null;
 
     /**
+     * Avoid serlialization of the test system object
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        $objectVars = get_object_vars($this);
+        unset($objectVars['testSystem']);
+
+        return $objectVars;
+    }
+
+    /**
      * Setup creates a test instance and database
      *
      * This method has to be called with parent::setUp() in your test cases


### PR DESCRIPTION
PHPUnit serializes the TestCase as port of the
result object, leading to serialization
(and unserialization) of the TestSystem and basically
the whole TYPO3 object graph in the bootstrap.

Avoid this by unsetting this property on serialization

Fixes: #22