### PR TITLE
[BUGFIX] Fix path to test environment

### DIFF
--- a/src/TestingFramework/Bootstrap/AbstractBootstrap.php
+++ b/src/TestingFramework/Bootstrap/AbstractBootstrap.php
@@ -124,7 +124,7 @@ abstract class AbstractBootstrap
 
         if (!file_exists(ORIGINAL_ROOT . 'typo3/index.php')) {
             $this->exitWithMessage('Unable to determine path to entry script.'
-                . ' Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your root path.'
+                . ' Please check your path or set an environment variable \'TYPO3_PATH_ROOT\' to your root path.'
             );
         }
     }
@@ -136,7 +136,9 @@ abstract class AbstractBootstrap
      */
     protected function getWebRoot()
     {
-        if (getenv('TYPO3_PATH_WEB')) {
+        if (getenv('TYPO3_PATH_ROOT')) {
+            $webRoot = getenv('TYPO3_PATH_ROOT');
+        } elseif (getenv('TYPO3_PATH_WEB')) {
             $webRoot = getenv('TYPO3_PATH_WEB');
         } else {
             $webRoot = getcwd();
@@ -195,7 +197,7 @@ abstract class AbstractBootstrap
         $_SERVER['SCRIPT_NAME'] = PATH_thisScript;
 
         if (!file_exists(PATH_thisScript)) {
-            $this->exitWithMessage('Unable to determine path to entry script. Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your root path.');
+            $this->exitWithMessage('Unable to determine path to entry script. Please check your path or set an environment variable \'TYPO3_PATH_ROOT\' to your root path.');
         }
     }
 
@@ -291,7 +293,7 @@ abstract class AbstractBootstrap
             } else {
                 $this->exitWithMessage('ClassLoader can\'t be loaded.'
                     . ' Tried to find "' . $classLoaderFilepath . '".'
-                    . ' Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your root path.'
+                    . ' Please check your path or set an environment variable \'TYPO3_PATH_ROOT\' to your root path.'
                 );
             }
         }

--- a/src/TestingFramework/TestSystem/AbstractTestSystem.php
+++ b/src/TestingFramework/TestSystem/AbstractTestSystem.php
@@ -190,6 +190,9 @@ abstract class AbstractTestSystem
         // Disable TYPO3_DLOG
         define('TYPO3_DLOG', false);
 
+        // Ensure TYPO3_PATH_ROOT is pointing to the document root of the test environment
+        // It will be evaluated in the TYPO3 bootstrap and a previously set value may interfere here
+        putenv('TYPO3_PATH_ROOT=' . rtrim($this->systemPath, '/'));
         $_SERVER['PWD'] = $this->systemPath;
         $_SERVER['argv'][0] = 'index.php';
     }
@@ -757,7 +760,7 @@ abstract class AbstractTestSystem
                 throw new Exception(
                     'ClassLoader can\'t be loaded.'
                     . ' Tried to find "' . $classLoaderFilepath . '".'
-                    . ' Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your root path.'
+                    . ' Please check your path or set an environment variable \'TYPO3_PATH_ROOT\' to your root path.'
                 );
             }
         }


### PR DESCRIPTION
If TYPO3_PATH_ROOT environment variable is set
before executing functional tests, we need to make
sure that we re-set it to the path of the test system
because the TYPO3 bootstrap since version 8 evaluates
this variable and PATH_site of the tests system would
point to the original root instead of the test system root.

Also evaluate TYPO3_PATH_ROOT as document root for unit tests