### PR TITLE
[BUGFIX] Initialize TYPO3 Backend Routing

### DIFF
--- a/compat/v76/TestSystem/TestSystem.php
+++ b/compat/v76/TestSystem/TestSystem.php
@@ -153,6 +153,7 @@ class TestSystem extends AbstractTestSystem
             ->baseSetup()
             ->loadConfigurationAndInitialize(true)
             ->loadTypo3LoadedExtAndExtLocalconf(true)
+            ->initializeBackendRouter()
             ->setFinalCachingFrameworkCacheConfiguration()
             ->defineLoggingAndExceptionConstants()
             ->unsetReservedGlobalVariables();

--- a/compat/v87/TestSystem/TestSystem.php
+++ b/compat/v87/TestSystem/TestSystem.php
@@ -33,6 +33,7 @@ class TestSystem extends AbstractTestSystem
             ->baseSetup()
             ->loadConfigurationAndInitialize(true)
             ->loadTypo3LoadedExtAndExtLocalconf(true)
+            ->initializeBackendRouter()
             ->setFinalCachingFrameworkCacheConfiguration()
             ->unsetReservedGlobalVariables()
             ->defineLoggingAndExceptionConstants();

--- a/src/TestingFramework/TestSystem/AbstractTestSystem.php
+++ b/src/TestingFramework/TestSystem/AbstractTestSystem.php
@@ -123,6 +123,7 @@ abstract class AbstractTestSystem
         $this->bootstrap->populateLocalConfiguration();
 
         $this->bootstrap->loadTypo3LoadedExtAndExtLocalconf(true)
+            ->initializeBackendRouter()
             ->setFinalCachingFrameworkCacheConfiguration()
             ->unsetReservedGlobalVariables();
     }


### PR DESCRIPTION
This includes Configuration/Backend/Routes.php and
Configuration/Backend/AjaxRoutes.php files if available and loads
\TYPO3\CMS\Backend\Routing\Router.