### PR TITLE
[BUGFIX] Prevent deprecation errors due to trigger_error

### DIFF
--- a/compat/v90/TestSystem/TestSystem.php
+++ b/compat/v90/TestSystem/TestSystem.php
@@ -13,6 +13,8 @@ namespace Nimut\TestingFramework\v90\TestSystem;
  */
 
 use Nimut\TestingFramework\TestSystem\AbstractTestSystem;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Service\ExtensionConfigurationService;
 
 class TestSystem extends AbstractTestSystem
@@ -41,5 +43,27 @@ class TestSystem extends AbstractTestSystem
             ->initializeBackendRouter()
             ->setFinalCachingFrameworkCacheConfiguration()
             ->unsetReservedGlobalVariables();
+    }
+
+    /**
+     * Loads TCA and ext_tables.php files from extensions
+     *
+     * @return void
+     */
+    protected function loadExtensionConfiguration()
+    {
+        $this->prepareDatabaseConnection();
+        $this->bootstrap->loadBaseTca(true)->loadExtTables(true);
+    }
+
+    /**
+     * Initializes default database connection
+     *
+     * @see https://forge.typo3.org/issues/83770
+     * @return void
+     */
+    protected function prepareDatabaseConnection()
+    {
+        GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('sys_log');
     }
 }

--- a/src/TestingFramework/TestSystem/AbstractTestSystem.php
+++ b/src/TestingFramework/TestSystem/AbstractTestSystem.php
@@ -242,7 +242,7 @@ abstract class AbstractTestSystem
     }
 
     /**
-     * Loads extension configuration from ext_localconf.php and ext_tables.php files
+     * Loads TCA and ext_tables.php files from extensions
      *
      * @return void
      */

--- a/src/TestingFramework/TestSystem/TestSystem.php
+++ b/src/TestingFramework/TestSystem/TestSystem.php
@@ -12,6 +12,30 @@ namespace Nimut\TestingFramework\TestSystem;
  * LICENSE file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 class TestSystem extends AbstractTestSystem
 {
+    /**
+     * Loads TCA and ext_tables.php files from extensions
+     *
+     * @return void
+     */
+    protected function loadExtensionConfiguration()
+    {
+        $this->prepareDatabaseConnection();
+        $this->bootstrap->loadBaseTca(true)->loadExtTables(true);
+    }
+
+    /**
+     * Initializes default database connection
+     *
+     * @see https://forge.typo3.org/issues/83770
+     * @return void
+     */
+    protected function prepareDatabaseConnection()
+    {
+        GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('sys_log');
+    }
 }

--- a/tests/Packages/testbase/Classes/Controller/DeprecationController.php
+++ b/tests/Packages/testbase/Classes/Controller/DeprecationController.php
@@ -1,0 +1,29 @@
+<?php
+namespace Nimut\Testbase\Controller;
+
+/*
+ * This file is part of the NIMUT testing-framework project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ */
+
+class DeprecationController
+{
+    /**
+     * @return bool
+     */
+    public function someDeprecatedMethod()
+    {
+        trigger_error(
+            'This is some deprecated method that will never be removed.',
+            E_USER_DEPRECATED
+        );
+
+        return true;
+    }
+}

--- a/tests/Packages/testbase/Tests/Functional/Controller/DeprecationControllerDisabledExceptionTest.php
+++ b/tests/Packages/testbase/Tests/Functional/Controller/DeprecationControllerDisabledExceptionTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace Nimut\Testbase\Tests\Functional\Controller;
+
+/*
+ * This file is part of the NIMUT testing-framework project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Nimut\Testbase\Controller\DeprecationController;
+use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+
+class DeprecationControllerDisabledExceptionTest extends FunctionalTestCase
+{
+    /**
+     * @var array
+     */
+    protected $configurationToUseInTestInstance = [
+        'SYS' => [
+            'exceptionalErrors' => E_ALL & ~(E_STRICT | E_NOTICE | E_COMPILE_WARNING | E_COMPILE_ERROR | E_CORE_WARNING | E_CORE_ERROR | E_PARSE | E_ERROR | E_DEPRECATED | E_USER_DEPRECATED | E_WARNING | E_USER_ERROR | E_USER_NOTICE | E_USER_WARNING),
+        ],
+    ];
+
+    /**
+     * @var DeprecationController
+     */
+    protected $deprecationController;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->deprecationController = new DeprecationController();
+    }
+
+    /**
+     * @test
+     */
+    public function someDeprecatedMethodThrowsNoExceptionIfDisabled()
+    {
+        $this->assertTrue($this->deprecationController->someDeprecatedMethod());
+    }
+}

--- a/tests/Packages/testbase/Tests/Functional/Controller/DeprecationControllerTypo3ExceptionTest.php
+++ b/tests/Packages/testbase/Tests/Functional/Controller/DeprecationControllerTypo3ExceptionTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace Nimut\Testbase\Tests\Functional\Controller;
+
+/*
+ * This file is part of the NIMUT testing-framework project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Nimut\Testbase\Controller\DeprecationController;
+use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+use TYPO3\CMS\Core\Error\Exception;
+
+class DeprecationControllerTypo3ExceptionTest extends FunctionalTestCase
+{
+    /**
+     * @var array
+     */
+    protected $configurationToUseInTestInstance = [
+        'SYS' => [
+            'exceptionalErrors' => E_ALL & ~(E_STRICT | E_NOTICE | E_COMPILE_WARNING | E_COMPILE_ERROR | E_CORE_WARNING | E_CORE_ERROR | E_PARSE | E_ERROR | E_WARNING | E_USER_ERROR | E_USER_NOTICE | E_USER_WARNING),
+        ],
+    ];
+
+    /**
+     * @var DeprecationController
+     */
+    protected $deprecationController;
+
+    protected function setUp()
+    {
+        if (!defined('ORIGINAL_ROOT')) {
+            $this->markTestSkipped('Functional tests must be called through phpunit on CLI');
+        }
+
+        $this->deprecationController = new DeprecationController();
+    }
+
+    /**
+     * @test
+     */
+    public function someDeprecatedMethodThrowsDeprecationMessage()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageRegExp('/^(PHP :|TYPO3 Deprecation Notice:)/');
+
+        parent::setUp();
+
+        $this->assertTrue($this->deprecationController->someDeprecatedMethod());
+    }
+}


### PR DESCRIPTION
This patch ensures the database connection is initialized before
any deprecation error is handled by \TYPO3\CMS\Core\Error\ErrorHandler.
This is important as currently TYPO3 enforces an opened database
connection if initCommands are set that are configured in testing-
framework configuration. Opening a database connection inside the
ErrorHandler triggers some Doctrine DBAL api that sets and resets own
error handlers. Resetting an error handler inside another error handler
seems to even reset the later one.