### PR TITLE
[BUGFIX] Allow to override database setting for function test system

### DIFF
--- a/src/TestingFramework/TestSystem/AbstractTestSystem.php
+++ b/src/TestingFramework/TestSystem/AbstractTestSystem.php
@@ -404,8 +404,8 @@ abstract class AbstractTestSystem
             $this->defaultConfiguration,
             $configurationToMerge
         );
-        $this->mergeRecursiveWithOverrule($finalConfigurationArray, $configurationToMerge);
         $finalConfigurationArray['DB'] = $this->setDatabaseName($originalConfigurationArray['DB']);
+        $this->mergeRecursiveWithOverrule($finalConfigurationArray, $configurationToMerge);
 
         $content = '<?php' . chr(10) . 'return '
             . var_export($finalConfigurationArray, true)


### PR DESCRIPTION
As the testing-framework sets ['DB']['Connections']['Default']['initCommands'] from its default configuration, there is currently no way to test without strict mode. If the configuration to override is applied at last, the user is able to define own database configuration.