### PR TITLE
[BUGFIX] Remove superfluous database field from be_users fixture file

### DIFF
--- a/res/Fixtures/Database/be_users.xml
+++ b/res/Fixtures/Database/be_users.xml
@@ -20,6 +20,5 @@
         <lastlogin>1371033743</lastlogin>
         <createdByAction>0</createdByAction>
         <workspace_id>0</workspace_id>
-        <workspace_preview>1</workspace_preview>
     </be_users>
 </dataset>


### PR DESCRIPTION
As the field was removed in https://review.typo3.org/55871/ and is set
to same same value by default in lower version, it can be removed from
the fixture file.