### PR TITLE
[BUGFIX] Enforce database name to be lowerstring

### DIFF
--- a/compat/v76/TestSystem/TestSystem.php
+++ b/compat/v76/TestSystem/TestSystem.php
@@ -216,7 +216,7 @@ class TestSystem extends AbstractTestSystem
             );
         }
 
-        $databaseConfiguration['database'] = $databaseName;
+        $databaseConfiguration['database'] = strtolower($databaseName);
 
         return $databaseConfiguration;
     }

--- a/src/TestingFramework/TestSystem/AbstractTestSystem.php
+++ b/src/TestingFramework/TestSystem/AbstractTestSystem.php
@@ -658,7 +658,7 @@ abstract class AbstractTestSystem
             );
         }
 
-        $databaseConfiguration['Connections']['Default']['dbname'] = $databaseName;
+        $databaseConfiguration['Connections']['Default']['dbname'] = strtolower($databaseName);
 
         return $databaseConfiguration;
     }


### PR DESCRIPTION
Because of comparison of database names in TestSystem::setUpTestDatabase
the case of the database name should be enforced. In earlier versions
of the TestSystem the database was dropped everytime (using IF EXISTS)
and the database formats the database name on its own.

Resolves: #78 