### PR TITLE
[BUGFIX] Remove importing fixtures for pages_language_overlay

### DIFF
--- a/tests/Packages/testbase/Tests/Functional/FunctionalTest.php
+++ b/tests/Packages/testbase/Tests/Functional/FunctionalTest.php
@@ -39,10 +39,8 @@ class FunctionalTest extends FunctionalTestCase
     public function loadPagesDatabaseFixtures()
     {
         $this->importDataSet('ntf://Database/pages.xml');
-        $this->importDataSet('ntf://Database/pages_language_overlay.xml');
 
         $this->assertSame(7, $this->getDatabaseConnection()->selectCount('*', 'pages'));
-        $this->assertSame(2, $this->getDatabaseConnection()->selectCount('*', 'pages_language_overlay'));
     }
 
     /**


### PR DESCRIPTION
In the upcoming version 9 LTS of TYPO3 the table pages_language_overlay
is removed and trying to import the fixture file will fail.