### PR TITLE
[BUGFIX] Prevent unsetting PHPUnit properties

### DIFF
--- a/src/TestingFramework/TestCase/UnitTestCase.php
+++ b/src/TestingFramework/TestCase/UnitTestCase.php
@@ -75,7 +75,7 @@ abstract class UnitTestCase extends AbstractTestCase
                 !$property->isStatic()
                 && $declaringClass !== 'Nimut\\TestingFramework\\TestCase\\AbstractTestCase'
                 && $declaringClass !== get_class($this)
-                && strpos($property->getDeclaringClass()->getName(), 'PHPUnit_') !== 0
+                && strpos($property->getDeclaringClass()->getName(), 'PHPUnit') !== 0
             ) {
                 $propertyName = $property->getName();
                 unset($this->$propertyName);


### PR DESCRIPTION
Since PHPUnit introduces namespaces, class name not starting with
"PHPUnit_" anymore, but "PHPUnit\". This patch ensures no PHPUnit
class property is unset for both cases.