### PR TITLE
Use different error type for exception test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,11 @@ before_install:
   - if php -i | grep -q xdebug; then phpenv config-rm xdebug.ini; fi
 
 install:
-  - if [ "$TYPO3" == "dev-master" ]; then composer config minimum-stability dev; fi
+  - >
+    if [ "$TYPO3" == "dev-master" ]; then
+      composer config minimum-stability dev;
+      composer config prefer-stable true;
+    fi
   - composer require nimut/typo3-complete="$TYPO3"
   - git checkout composer.json
   - export TYPO3_PATH_WEB=$PWD/.Build/Web

--- a/tests/Packages/testbase/Classes/Controller/DeprecationController.php
+++ b/tests/Packages/testbase/Classes/Controller/DeprecationController.php
@@ -21,7 +21,7 @@ class DeprecationController
     {
         trigger_error(
             'This is some deprecated method that will never be removed.',
-            E_USER_DEPRECATED
+            E_USER_WARNING
         );
 
         return true;

--- a/tests/Packages/testbase/Tests/Functional/Controller/DeprecationControllerTypo3ExceptionTest.php
+++ b/tests/Packages/testbase/Tests/Functional/Controller/DeprecationControllerTypo3ExceptionTest.php
@@ -23,7 +23,7 @@ class DeprecationControllerTypo3ExceptionTest extends FunctionalTestCase
      */
     protected $configurationToUseInTestInstance = [
         'SYS' => [
-            'exceptionalErrors' => E_ALL & ~(E_STRICT | E_NOTICE | E_COMPILE_WARNING | E_COMPILE_ERROR | E_CORE_WARNING | E_CORE_ERROR | E_PARSE | E_ERROR | E_WARNING | E_USER_ERROR | E_USER_NOTICE | E_USER_WARNING),
+            'exceptionalErrors' => E_ALL & ~(E_STRICT | E_NOTICE | E_COMPILE_WARNING | E_COMPILE_ERROR | E_CORE_WARNING | E_CORE_ERROR | E_PARSE | E_ERROR | E_DEPRECATED | E_USER_DEPRECATED | E_WARNING | E_USER_ERROR | E_USER_NOTICE),
         ],
     ];
 
@@ -47,7 +47,7 @@ class DeprecationControllerTypo3ExceptionTest extends FunctionalTestCase
     public function someDeprecatedMethodThrowsDeprecationMessage()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/^(PHP :|TYPO3 Deprecation Notice:)/');
+        $this->expectExceptionMessageRegExp('/^(PHP :|PHP User Warning:)/');
 
         parent::setUp();
 


### PR DESCRIPTION
As TYPO3 prevents exceptions for E_USER_DEPRECATED error type, the
testing framework needs to change triggered error for exception
tests.