### PR TITLE
[TASK] Do not convert deprecations to exceptions

### DIFF
--- a/res/Configuration/FunctionalTests.xml
+++ b/res/Configuration/FunctionalTests.xml
@@ -5,6 +5,7 @@
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="false"
 	forceCoversAnnotation="false"
 	processIsolation="true"
 	stopOnError="false"

--- a/res/Configuration/UnitTests.xml
+++ b/res/Configuration/UnitTests.xml
@@ -5,6 +5,7 @@
     colors="true"
     convertErrorsToExceptions="true"
     convertWarningsToExceptions="true"
+    convertDeprecationsToExceptions="false"
     forceCoversAnnotation="false"
     processIsolation="false"
     stopOnError="false"


### PR DESCRIPTION
Deprecations in TYPO3 v9 will trigger an error with E_USER_DEPRECATED
resulting in unit tests using deprecated core functions to fail.

This patch updates the text configuration, so deprecations will not
be converted to exceptions