### PR TITLE
Correctly remove pathsToLinkInTestInstance in tearDown

### DIFF
--- a/src/TestingFramework/TestCase/FunctionalTestCase.php
+++ b/src/TestingFramework/TestCase/FunctionalTestCase.php
@@ -209,7 +209,7 @@ abstract class FunctionalTestCase extends AbstractTestCase
         parent::tearDown();
 
         foreach ($this->pathsToLinkInTestInstance as $destination) {
-            @unlink($destination);
+            GeneralUtility::rmdir($this->testSystem->getSystemPath() . ltrim($destination, '/'));
         }
     }
 


### PR DESCRIPTION
As there is no information if the pathsToLinkInTestInstance are files or
folders, the testing framework should use GeneralUtility::rmdir to
remove the created symlinks.