### PR TITLE
[TASK] Support frontend requests in case of helhum/typo3-secure-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ $structure = $defaultSection->getStructure();
 $this->assertTrue(is_array($structure['pages:1']['__contents']['tt_content:1']));
 ```
 
+In case of using helhum/typo3-secure-web do not forget to set TYPO3_PATH_WEB to your web-dir folder
+
 #### Structure
 
 The returned structure of a frontend request is an array with some information about your page and its children.
@@ -203,3 +205,7 @@ Following links provide documentation and additional information about TYPO3 CMS
 - [Functional tests for dummies](https://de.slideshare.net/cpsitgmbh/functional-tests-for-dummies-65673214)
 
 Last but not least you may ask for further support in the Slack channel "[#cig-testing](https://typo3.slack.com/messages/cig-testing)".
+
+## helhum/typo3-secure-web compatibility
+
+In case of using helhum/typo3-secure-web you should set TYPO3_PATH_ROOT to your private dir, and TYPO3_PATH_WEB to the public one.

--- a/src/TestingFramework/Bootstrap/AbstractBootstrap.php
+++ b/src/TestingFramework/Bootstrap/AbstractBootstrap.php
@@ -81,6 +81,7 @@ abstract class AbstractBootstrap
         $this->enableDisplayErrors();
         $this->createNecessaryDirectoriesInDocumentRoot();
         $this->defineOriginalRootPath();
+        $this->defineOriginalWebPath();
     }
 
     /**
@@ -152,6 +153,27 @@ abstract class AbstractBootstrap
     }
 
     /**
+     * Defines the constant ORIGINAL_WEB for the path to the web(public) TYPO3 root dir
+     * In case of using helhum/typo3-secure-web your private and public sources can have different root paths
+     *
+     * @return void
+     */
+    protected function defineOriginalWebPath()
+    {
+        if (!defined('ORIGINAL_WEB')) {
+            /** @var string */
+            define('ORIGINAL_WEB', $this->getPublicRootPath());
+        }
+
+        if (!file_exists(ORIGINAL_WEB . 'index.php')) {
+            $this->exitWithMessage(
+                'Unable to determine path to entry script.'
+                . ' Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your public root path.'
+            );
+        }
+    }
+
+    /**
      * Returns the absolute path to the TYPO3 document root
      *
      * @return string the TYPO3 document root using Unix path separators
@@ -167,6 +189,24 @@ abstract class AbstractBootstrap
         }
 
         return rtrim(str_replace('\\', '/', $webRoot), '/') . '/';
+    }
+
+    /**
+     * Returns the absolute path to the TYPO3 public root dir
+     *
+     * @return string the TYPO3 public root using Unix path separators
+     */
+    protected function getPublicRootPath()
+    {
+        if (getenv('TYPO3_PATH_WEB')) {
+            $publicRoot = getenv('TYPO3_PATH_WEB');
+        } elseif (getenv('TYPO3_PATH_ROOT')) {
+            $publicRoot = getenv('TYPO3_PATH_ROOT');
+        } else {
+            $publicRoot = getcwd();
+        }
+
+        return rtrim(str_replace('\\', '/', $publicRoot), '/') . '/';
     }
 
     /**

--- a/src/TestingFramework/TestSystem/AbstractTestSystem.php
+++ b/src/TestingFramework/TestSystem/AbstractTestSystem.php
@@ -307,7 +307,7 @@ abstract class AbstractTestSystem
     {
         $linksToSet = [
             ORIGINAL_ROOT . 'typo3' => $this->systemPath . 'typo3',
-            ORIGINAL_ROOT . 'index.php' => $this->systemPath . 'index.php',
+            ORIGINAL_WEB . 'index.php' => $this->systemPath . 'index.php',
         ];
         foreach ($linksToSet as $from => $to) {
             if (!symlink($from, $to)) {
@@ -337,11 +337,14 @@ abstract class AbstractTestSystem
                 );
             }
             $destinationPath = $this->systemPath . 'typo3conf/ext/' . basename($absoluteExtensionPath);
-            if (!symlink($absoluteExtensionPath, $destinationPath)) {
-                throw new Exception(
-                    'Can not link extension folder: ' . $absoluteExtensionPath . ' to ' . $destinationPath,
-                    1376657142
-                );
+
+            if (!file_exists($destinationPath)) {
+                if (!symlink($absoluteExtensionPath, $destinationPath)) {
+                    throw new Exception(
+                        'Can not link extension folder: ' . $absoluteExtensionPath . ' to ' . $destinationPath,
+                        1376657142
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
== Description ==
On our project we are using helhum/typo3-secure-web package together with nimut/testing-framework, and we got an issue when running FunctionalTests together with frontend requests.
As we are using helhum/typo3-secure-web we have a private folder and public folder in the project. And we wrote a functional test to check if frontend request will response with the data we expect (we are using this: https://github.com/Nimut/testing-framework#frontend-requests), TYPO3_PATH_ROOT is set to the private folder, however /private/index.php file is empty, and because of that frontend answers with empty response. So looks like nimut/testing-framework doesn't expect a compatibility with helhum/typo3-secure-web.

== What was changed? ==
As I see TYPO3_PATH_WEB is used in the code too, but actually in the current state it is only used to define ORIGINAL_ROOT in case when TYPO3_PATH_ROOT isn't set.

So we are defining a new constant ORIGINAL_WEB which will use value from TYPO3_PATH_WEB or if it is empty then from TYPO3_PATH_ROOT. In this case we can separate our private environment and public environment by next constants: ORIGINAL_ROOT and ORIGINAL_WEB, which will have the same value in the code in case when user sets only one of them.

And in the place where we are preparing testing environment we are linking our index.php from testing env to the index.php from root which is set by TYPO3_PATH_WEB. 