### PR TITLE
Removing deleting linked files/folder in teardown

### DIFF
--- a/src/TestingFramework/TestCase/FunctionalTestCase.php
+++ b/src/TestingFramework/TestCase/FunctionalTestCase.php
@@ -207,10 +207,6 @@ abstract class FunctionalTestCase extends AbstractTestCase
     protected function tearDown()
     {
         parent::tearDown();
-
-        foreach ($this->pathsToLinkInTestInstance as $destination) {
-            GeneralUtility::rmdir($this->testSystem->getSystemPath() . ltrim($destination, '/'));
-        }
     }
 
     /**


### PR DESCRIPTION
Since it doesn't seem to be necessary the loop to delete the linked files/folder has been removed.

When executing multiple tests in a class which access the same linked files/folder these will be currently removed after the first test finished. This will result in all test failing afterwards when also accessing these linked files/folders.