### PR TITLE
Revert removing pathsToLinkInTestInstance in tearDown

### DIFF
--- a/src/TestingFramework/TestCase/FunctionalTestCase.php
+++ b/src/TestingFramework/TestCase/FunctionalTestCase.php
@@ -202,18 +202,6 @@ abstract class FunctionalTestCase extends AbstractTestCase
     }
 
     /**
-     * Remove symlinks that were created during setUp
-     */
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        foreach ($this->pathsToLinkInTestInstance as $destination) {
-            GeneralUtility::rmdir($this->testSystem->getSystemPath() . ltrim($destination, '/'));
-        }
-    }
-
-    /**
      * Returns the system identifier
      *
      * @return string

--- a/tests/Packages/testbase/Tests/Functional/TestSystem/TestSystemTest.php
+++ b/tests/Packages/testbase/Tests/Functional/TestSystem/TestSystemTest.php
@@ -13,6 +13,7 @@ namespace Nimut\Testbase\Tests\Functional\TestSystem;
  */
 
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class TestSystemTest extends FunctionalTestCase
 {
@@ -45,7 +46,7 @@ class TestSystemTest extends FunctionalTestCase
         parent::tearDown();
 
         foreach ($this->pathsToLinkInTestInstance as $destination) {
-            @unlink($this->getInstancePath() . $destination);
+            GeneralUtility::rmdir($this->getInstancePath() . ltrim($destination, '/'));
         }
     }
 


### PR DESCRIPTION
Backport of #126 

Related: #125 