### PR TITLE
[FEATURE] Copy ExtensionTestEnvironment from TYPO3 testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,26 @@ jobs:
             php: 7.0
             env: TYPO3=^8.7
 
+        - &prepare
+            stage: ✔ extension preparation
+            before_script:
+                - if php -i | grep -v TRAVIS_CMD | grep -q xdebug; then phpenv config-rm xdebug.ini; fi
+                - mkdir -p tests/Packages/testbase/Tests/Packages/testing-framework
+                - rsync -a --delete --exclude ".*" --exclude "tests" . tests/Packages/testbase/Tests/Packages/testing-framework
+            script:
+                - cd tests/Packages/testbase/
+                - composer install
+                - grep "Testbase extension for nimut/testing-framework" .Build/public/typo3conf/ext/testbase/composer.json
+            php: 7.4
+        -   <<: *prepare
+            php: 7.3
+        -   <<: *prepare
+            php: 7.2
+        -   <<: *prepare
+            php: 7.1
+        -   <<: *prepare
+            php: 7.0
+
         -   stage: ✔ with sonarqube scanner
             if: type = push AND branch IN (master, pre-merge) AND env(SONAR_TOKEN) IS present AND fork = false
             git:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ $ vendor/bin/phpunit -c vendor/nimut/testing-framework/res/Configuration/Functio
     typo3conf/ext/example_extension/Tests/Functional
 ```
 
+### Extension preparation
+
+You can add a script section to your `composer.json` file to symlink your extension to the proper root-dir/web-dir.
+
+```json
+"scripts": {
+    "post-autoload-dump": [
+        "@prepare-extension-test-structure"
+    ],
+    "prepare-extension-test-structure": [
+        "Nimut\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
+    ]
+}
+```
+
 ### Database abstraction
 
 To be able to test against TYPO3 CMS 8 and later, nimut/testing-framework provides an own database abstraction layer.

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "mikey179/vfsstream": "^1.6"
     },
     "require-dev": {
+        "composer/composer": "^1.10",
         "nimut/testing-framework-testbase": "@dev",
         "nimut/phpunit-merger": "^0.3"
     },

--- a/src/TestingFramework/Composer/ExtensionTestEnvironment.php
+++ b/src/TestingFramework/Composer/ExtensionTestEnvironment.php
@@ -1,0 +1,84 @@
+<?php
+namespace Nimut\TestingFramework\Composer;
+
+/*
+ * This file is part of the NIMUT testing-framework project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Composer\Script\Event;
+
+/**
+ * If a TYPO3 extension should be tested, the extension needs to be embedded in
+ * a TYPO3 instance. The composer.json file of the extension then acts as a
+ * root composer.json file that creates a TYPO3 project around the extension code
+ * in a build folder like "./.Build". The to-test extension then needs to reside
+ * in ./.Build/Web/typo3conf/ext. This composer script takes care of this operation
+ * and links the current root directory as "./<web-dir>/typo3conf/ext/<extension-key>".
+ *
+ * This class is added as composer "script" in TYPO3 extensions:
+ *
+ *   "scripts": {
+ *     "post-autoload-dump": [
+ *       "@prepare-extension-test-environment"
+ *     ],
+ *     "prepare-extension-test-structure": [
+ *       "Nimut\TestingFramework\Composer\ExtensionTestEnvironment::prepare"
+ *     ]
+ *   },
+ *
+ * It additionally needs the "extension key" (that will become the directory name in
+ * typo3conf/ext) and the name of the target directory in the extra section. Example for
+ * a extension "my_cool_extension":
+ *
+ *   "extra": {
+ *     "typo3/cms": {
+ *       "web-dir": ".Build/Web",
+ *       "extension-key": "my_cool_extension"
+ *     }
+ *   }
+ */
+final class ExtensionTestEnvironment
+{
+    /**
+     * Link directory that contains the composer.json file as
+     * ./<web-dir>/typo3conf/ext/<extension-key>.
+     *
+     * @param Event $event
+     */
+    public static function prepare(Event $event)
+    {
+        $composerConfigExtraSection = $event->getComposer()->getPackage()->getExtra();
+        if (empty($composerConfigExtraSection['typo3/cms']['extension-key'])
+            || empty($composerConfigExtraSection['typo3/cms']['web-dir'])
+        ) {
+            throw new \RuntimeException(
+                'This script needs properties in composer.json:'
+                    . '"extra" "typo3/cms" "extension-key"'
+                    . ' and "extra" "typo3/cms" "web-dir"',
+                1540644486
+            );
+        }
+        $extensionKey = $composerConfigExtraSection['typo3/cms']['extension-key'];
+        $webDir = $composerConfigExtraSection['typo3/cms']['web-dir'];
+        $typo3confExt = __DIR__ . '/../../../../../../' . $webDir . '/typo3conf/ext';
+        if (!is_dir($typo3confExt) &&
+            !mkdir($typo3confExt, 0775, true) &&
+            !is_dir($typo3confExt)
+        ) {
+            throw new \RuntimeException(
+                sprintf('Directory "%s" could not be created', $typo3confExt),
+                1540650485
+            );
+        }
+        if (!is_link($typo3confExt . '/' . $extensionKey)) {
+            symlink(dirname(__DIR__, 6) . '/', $typo3confExt . '/' . $extensionKey);
+        }
+    }
+}

--- a/src/TestingFramework/Composer/ExtensionTestEnvironment.php
+++ b/src/TestingFramework/Composer/ExtensionTestEnvironment.php
@@ -16,31 +16,31 @@ use Composer\Script\Event;
 
 /**
  * If a TYPO3 extension should be tested, the extension needs to be embedded in
- * a TYPO3 instance. The composer.json file of the extension then acts as a
- * root composer.json file that creates a TYPO3 project around the extension code
- * in a build folder like "./.Build". The to-test extension then needs to reside
- * in ./.Build/Web/typo3conf/ext. This composer script takes care of this operation
- * and links the current root directory as "./<web-dir>/typo3conf/ext/<extension-key>".
+ * a TYPO3 instance. The composer.json file of the extension creates a
+ * TYPO3 project around the extension code in a build folder like "./.Build".
+ * The to-test extension then needs to reside in ./.Build/public/typo3conf/ext.
+ * This composer script takes care of this operation and links the current
+ * root directory as "./<root-dir>/typo3conf/ext/<extension-key>".
  *
  * This class is added as composer "script" in TYPO3 extensions:
  *
  *   "scripts": {
  *     "post-autoload-dump": [
- *       "@prepare-extension-test-environment"
+ *       "@prepare-extension-test-structure"
  *     ],
  *     "prepare-extension-test-structure": [
- *       "Nimut\TestingFramework\Composer\ExtensionTestEnvironment::prepare"
+ *       "Nimut\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
  *     ]
  *   },
  *
  * It additionally needs the "extension key" (that will become the directory name in
  * typo3conf/ext) and the name of the target directory in the extra section. Example for
- * a extension "my_cool_extension":
+ * a extension "my_extension":
  *
  *   "extra": {
  *     "typo3/cms": {
- *       "web-dir": ".Build/Web",
- *       "extension-key": "my_cool_extension"
+ *       "web-dir": ".Build/public",
+ *       "extension-key": "my_extension"
  *     }
  *   }
  */
@@ -48,7 +48,7 @@ final class ExtensionTestEnvironment
 {
     /**
      * Link directory that contains the composer.json file as
-     * ./<web-dir>/typo3conf/ext/<extension-key>.
+     * ./<root-dir>/typo3conf/ext/<extension-key>.
      *
      * @param Event $event
      */

--- a/tests/Packages/testbase/composer.json
+++ b/tests/Packages/testbase/composer.json
@@ -17,9 +17,18 @@
             "homepage": "http://helhum.io"
         }
     ],
+    "repositories": [
+        {
+            "type": "path",
+            "url": "Tests/Packages/*"
+        }
+    ],
     "require": {
         "typo3/cms-core": "^8.7 || ^9.5 || ^10.4 || dev-master",
         "typo3/cms-fluid": "^8.7 || ^9.5 || ^10.4 || dev-master"
+    },
+    "require-dev": {
+        "nimut/testing-framework": "@dev"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +36,24 @@
             "Nimut\\Testbase\\Tests\\": "Tests/"
         }
     },
-    "replace": {
-        "testbase": "self.version"
+    "config": {
+        "vendor-dir": ".Build/vendor",
+        "bin-dir": ".Build/bin"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "testbase",
+            "cms-package-dir": "{$vendor-dir}/typo3/cms",
+            "app-dir": ".Build",
+            "web-dir": ".Build/public"
+        }
+    },
+    "scripts": {
+        "post-autoload-dump": [
+            "@prepare-extension-test-structure"
+        ],
+        "prepare-extension-test-structure": [
+            "Nimut\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
+        ]
     }
 }


### PR DESCRIPTION
This class is added as composer "script" in TYPO3 extensions:

```json
"scripts": {
     "post-autoload-dump": [
          "@prepare-extension-test-environment"
     ],
     "prepare-extension-test-structure": [
          "Nimut\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
     ]
},
```