### PR TITLE
[BUGFIX] Get the FunctionalTests test to run in TYPO3 11

### DIFF
--- a/tests/Packages/testbase/Tests/Functional/FunctionalTest.php
+++ b/tests/Packages/testbase/Tests/Functional/FunctionalTest.php
@@ -14,8 +14,10 @@ namespace Nimut\Testbase\Tests\Functional;
  */
 
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+use TYPO3\CMS\Backend\Routing\Router;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class FunctionalTest extends FunctionalTestCase
 {
@@ -62,7 +64,9 @@ class FunctionalTest extends FunctionalTestCase
      */
     public function routesAreInitialized()
     {
-        $uriBuilder = new UriBuilder();
+        /** @var Router $router */
+        $router = GeneralUtility::makeInstance(Router::class);
+        $uriBuilder = new UriBuilder($router);
         $uri = $uriBuilder->buildUriFromRoute('login', [], UriBuilder::ABSOLUTE_PATH);
 
         $this->assertInstanceOf(Uri::class, $uri);


### PR DESCRIPTION
The `UriBuilder` constructor now requires a `Router` instance.