### PR TITLE
[TASK] Remove dollar symbol in bash scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of the TYPO3 CMS. Currently **TYPO3 CMS 9.5 up to 11.5** are tested and supporte
 Use [Composer](https://getcomposer.org/) to install the testing framework.
 
 ```bash
-$ composer require --dev nimut/testing-framework
+composer require --dev nimut/testing-framework
 ```
 
 Composer will add the package as a dev requirement to your composer.json and install PHPUnit and vfsStream as its
@@ -27,7 +27,7 @@ Inherit your test class from `\Nimut\TestingFramework\TestCase\UnitTestCase`.
 To execute the unit tests of your extension run
 
 ```bash
-$ vendor/bin/phpunit -c vendor/nimut/testing-framework/res/Configuration/UnitTests.xml \
+vendor/bin/phpunit -c vendor/nimut/testing-framework/res/Configuration/UnitTests.xml \
     typo3conf/ext/example_extension/Tests/Unit
 ```
 
@@ -59,7 +59,7 @@ Inherit your test class from `\Nimut\TestingFramework\TestCase\FunctionalTestCas
 To execute the functional tests of your extension run
 
 ```bash
-$ vendor/bin/phpunit -c vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml \
+vendor/bin/phpunit -c vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml \
     typo3conf/ext/example_extension/Tests/Functional
 ```
 


### PR DESCRIPTION
To be able to copy the command in GitHub, the dollar symbol must be removed.