### PR TITLE
[BUGFIX] Fix return type of `lastInsertId()`

### DIFF
--- a/src/TestingFramework/Database/Database.php
+++ b/src/TestingFramework/Database/Database.php
@@ -97,7 +97,7 @@ class Database implements DatabaseInterface
      */
     public function lastInsertId()
     {
-        return $this->connection->lastInsertId();
+        return (int)$this->connection->lastInsertId();
     }
 
     /**


### PR DESCRIPTION
This method promises to return an int, but returned a string instead,
and hence needed a typecast.